### PR TITLE
Don't add commands if already existing

### DIFF
--- a/autoload/pres.vim
+++ b/autoload/pres.vim
@@ -116,8 +116,10 @@ function! pres#start(filename) abort "{{{
 
 	nnoremap <silent> <buffer> <Leader>n :call pres#next()<CR>
 	nnoremap <silent> <buffer> <Leader>p :call pres#prev()<CR>
-	command -buffer -nargs=1 PresGoto call pres#goto(<f-args>)
-	command -buffer -nargs=0 PresReload call s:showSlide(w:index)
+	if !exists(":PresGoto")
+		command -buffer -nargs=1 PresGoto call pres#goto(<f-args>)
+		command -buffer -nargs=0 PresReload call s:showSlide(w:index)
+	endif
 
 	call s:showSlide(w:index)
 endfunction "}}}

--- a/autoload/pres.vim
+++ b/autoload/pres.vim
@@ -116,10 +116,8 @@ function! pres#start(filename) abort "{{{
 
 	nnoremap <silent> <buffer> <Leader>n :call pres#next()<CR>
 	nnoremap <silent> <buffer> <Leader>p :call pres#prev()<CR>
-	if !exists(":PresGoto")
-		command -buffer -nargs=1 PresGoto call pres#goto(<f-args>)
-		command -buffer -nargs=0 PresReload call s:showSlide(w:index)
-	endif
+	command! -buffer -nargs=1 PresGoto call pres#goto(<f-args>)
+	command! -buffer -nargs=0 PresReload call s:showSlide(w:index)
 
 	call s:showSlide(w:index)
 endfunction "}}}


### PR DESCRIPTION
Fixes the error messages that appear when we use `:PresStart` for the second time on the same slide.